### PR TITLE
Small clarification for inheritance example

### DIFF
--- a/docs/01-coding-standards.md
+++ b/docs/01-coding-standards.md
@@ -93,6 +93,8 @@ In some cases it can be helpful to extend a part of the parent's docblock. For i
 interface A 
 {
     /**
+     * Creates a new foo by adding some bars
+     *
      * @param A $a
      */
     public function foo(A $a);
@@ -105,7 +107,9 @@ class B implements A
      *
      * @param B $a
      */
-    public function foo(A $a) {}
+    public function foo(B $a) {
+        // ...
+    }
 }
 ```
 

--- a/docs/01-coding-standards.md
+++ b/docs/01-coding-standards.md
@@ -107,7 +107,7 @@ class B implements A
      *
      * @param B $a
      */
-    public function foo(B $a) {
+    public function foo(A $a) {
         // ...
     }
 }


### PR DESCRIPTION
We missed a reason for using @inheritdoc in this example: there was nothing to inherit as the `@param` was already being overridden (`A` -> `B`).